### PR TITLE
Corrects colour of google-drive icon in 16x16 style 6

### DIFF
--- a/files/6/Numix/16x16/places/default-folder-google-drive.svg
+++ b/files/6/Numix/16x16/places/default-folder-google-drive.svg
@@ -13,8 +13,8 @@
    height="16"
    id="svg3139"
    version="1.1"
-   inkscape:version="0.48.5 r10040"
-   sodipodi:docname="folder-google-drive.svg">
+   inkscape:version="0.91 r"
+   sodipodi:docname="default-folder-google-drive.svg">
   <defs
      id="defs3141" />
   <sodipodi:namedview
@@ -24,16 +24,16 @@
      borderopacity="1.0"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="31.678384"
-     inkscape:cx="8.4320706"
-     inkscape:cy="5.5637259"
+     inkscape:zoom="11.2"
+     inkscape:cx="-6.3947822"
+     inkscape:cy="-1.575488"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="true"
-     inkscape:window-width="1280"
-     inkscape:window-height="998"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
      inkscape:window-x="0"
-     inkscape:window-y="0"
+     inkscape:window-y="21"
      inkscape:window-maximized="1">
     <inkscape:grid
        type="xygrid"
@@ -63,15 +63,15 @@
     <polygon
        id="polygon3475-1"
        transform="matrix(1.139731e-4,0,0,1.0404008e-4,0.82379851,1039.3621)"
-       style="opacity:1;fill:#ffa726;fill-opacity:1;fill-rule:evenodd"
+       style="opacity:1;fill:#ff9800;fill-opacity:1;fill-rule:evenodd"
        points="110963,115341 22194,115341 44385,76894 133156,76894 " />
     <polygon
        id="polygon3477-6"
        transform="matrix(1.1264941e-4,0,0,1.1704449e-4,1.0000561,1037.3622)"
-       style="opacity:1;fill:#ffa726;fill-opacity:1;fill-rule:evenodd"
+       style="opacity:1;fill:#ff9800;fill-opacity:1;fill-rule:evenodd"
        points="133156,76894 88772,0 44385,0 88772,76894 " />
     <path
-       style="opacity:1;fill:#ffa726;fill-opacity:1;fill-rule:evenodd"
+       style="opacity:1;fill:#ff9800;fill-opacity:1;fill-rule:evenodd"
        d="m 5.2,1038.1622 -4.97678571,8.0259 2.33035711,4.6652 L 7.4,1042.3622 z"
        id="polygon3479-9"
        inkscape:connector-curvature="0"


### PR DESCRIPTION
Colour of google drive icon in style 6 for 16x16 was inconsistent