### PR TITLE
Fixes colour inconsistency in style 2

### DIFF
--- a/styles/2/Numix/48x48/places/blue-user-home.svg
+++ b/styles/2/Numix/48x48/places/blue-user-home.svg
@@ -12,8 +12,8 @@
    height="48"
    id="svg2999"
    version="1.1"
-   inkscape:version="0.48.5 r10040"
-   sodipodi:docname="user-home.svg">
+   inkscape:version="0.91 r"
+   sodipodi:docname="blue-user-home.svg">
   <metadata
      id="metadata3017">
     <rdf:RDF>
@@ -36,15 +36,15 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1280"
-     inkscape:window-height="998"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
      id="namedview3013"
      showgrid="true"
-     inkscape:zoom="4.9166667"
-     inkscape:cx="7.8270076"
-     inkscape:cy="55.267371"
+     inkscape:zoom="3.4766083"
+     inkscape:cx="-55.418371"
+     inkscape:cy="58.867343"
      inkscape:window-x="0"
-     inkscape:window-y="0"
+     inkscape:window-y="21"
      inkscape:window-maximized="1"
      inkscape:current-layer="svg2999">
     <inkscape:grid
@@ -62,27 +62,8 @@
      style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#000000;fill-opacity:0.32156863;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
      d="m 6.000023,6.0000005 c -1,0 -2,0.9999995 -2,1.9999995 l 0,2 -1,0 c -1,0 -2.00556897,0.949207 -2,2 l 0,28 c 1.28e-4,1.120734 1.037763,1.9999 2.1875,2 l 41.625,0 c 1.1875,0 2.1875,-1 2.1875,-2 l 0,-25 c 0,-1 -1,-2 -2,-2 l -2,0 0,-5 c 0,-1 -1,-1.9999995 -2,-1.9999995 l -35,0 z m -3,4.9999995 24,0 c 0.507314,0 1,0.494167 1,1 l 0,2 17,0 c 0.540858,0 1,0.471809 1,1 l 0,25 c 0,0.553755 -0.452115,1 -1,1 l -42,0 c -0.512726,0 -1,-0.446246 -1,-1 l 0,-28 c 0,-0.543318 0.479042,-1 1,-1 z"
      id="path3779" />
-  <g
-     id="g4056"
-     transform="translate(16,20)"
-     style="opacity:0.4;fill:#3c2f1b;fill-opacity:1">
-    <path
-       sodipodi:nodetypes="cssccccsscc"
-       inkscape:connector-curvature="0"
-       id="rect2989"
-       d="m 2,7 0,7 c 0,1.108 0.892,2 2,2 l 2,0 0,-6 4,0 0,6 2,0 c 1.108,0 2,-0.892 2,-2 l 0,-7 z"
-       style="fill:#3c2f1b;fill-opacity:1" />
-    <path
-       sodipodi:nodetypes="ccccccc"
-       inkscape:connector-curvature="0"
-       id="path3761"
-       d="m 2,6 c -2.20338983,2 -3,2 0,2 l 12,0 c 3,0 2.288136,0 0,-2 L 9,1 C 8,0 8,0 7,1 z"
-       style="fill:#3c2f1b;fill-opacity:1;stroke:none" />
-    <path
-       sodipodi:nodetypes="ssccss"
-       inkscape:connector-curvature="0"
-       id="rect3763"
-       d="m 13,1 c 1,0 1,0.446 1,1 l 0,4 -2,0 0,-4 c 0,-0.554 0,-1 1,-1 z"
-       style="fill:#3c2f1b;fill-opacity:1;stroke:none" />
-  </g>
+  <path
+     style="fill:#000000;fill-opacity:0.32156864"
+     d="M 24 20.25 C 23.75 20.25 23.5 20.5 23 21 L 18 26 C 15.79661 28 15 28 18 28 L 18 34 C 18 35.108 18.892 36 20 36 L 22 36 L 22 30 L 26 30 L 26 36 L 28 36 C 29.108 36 30 35.108 30 34 L 30 28 C 33 28 32.288136 28 30 26 L 30 22 C 30 21.446 30 21 29 21 C 28 21 28 21.446 28 22 L 28 24 L 25 21 C 24.5 20.5 24.25 20.25 24 20.25 z "
+     id="rect2989" />
 </svg>

--- a/styles/2/Numix/48x48/places/brown-user-home.svg
+++ b/styles/2/Numix/48x48/places/brown-user-home.svg
@@ -12,8 +12,8 @@
    height="48"
    id="svg2999"
    version="1.1"
-   inkscape:version="0.48.5 r10040"
-   sodipodi:docname="user-home.svg">
+   inkscape:version="0.91 r"
+   sodipodi:docname="brown-user-home.svg">
   <metadata
      id="metadata3017">
     <rdf:RDF>
@@ -36,15 +36,15 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1280"
-     inkscape:window-height="998"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
      id="namedview3013"
      showgrid="true"
      inkscape:zoom="4.9166667"
-     inkscape:cx="7.8270076"
-     inkscape:cy="55.267371"
+     inkscape:cx="-37.935704"
+     inkscape:cy="38.996185"
      inkscape:window-x="0"
-     inkscape:window-y="0"
+     inkscape:window-y="21"
      inkscape:window-maximized="1"
      inkscape:current-layer="svg2999">
     <inkscape:grid
@@ -62,27 +62,8 @@
      style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#000000;fill-opacity:0.32156863;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
      d="m 6.000023,6.0000005 c -1,0 -2,0.9999995 -2,1.9999995 l 0,2 -1,0 c -1,0 -2.00556897,0.949207 -2,2 l 0,28 c 1.28e-4,1.120734 1.037763,1.9999 2.1875,2 l 41.625,0 c 1.1875,0 2.1875,-1 2.1875,-2 l 0,-25 c 0,-1 -1,-2 -2,-2 l -2,0 0,-5 c 0,-1 -1,-1.9999995 -2,-1.9999995 l -35,0 z m -3,4.9999995 24,0 c 0.507314,0 1,0.494167 1,1 l 0,2 17,0 c 0.540858,0 1,0.471809 1,1 l 0,25 c 0,0.553755 -0.452115,1 -1,1 l -42,0 c -0.512726,0 -1,-0.446246 -1,-1 l 0,-28 c 0,-0.543318 0.479042,-1 1,-1 z"
      id="path3779" />
-  <g
-     id="g4056"
-     transform="translate(16,20)"
-     style="opacity:0.4;fill:#3c2f1b;fill-opacity:1">
-    <path
-       sodipodi:nodetypes="cssccccsscc"
-       inkscape:connector-curvature="0"
-       id="rect2989"
-       d="m 2,7 0,7 c 0,1.108 0.892,2 2,2 l 2,0 0,-6 4,0 0,6 2,0 c 1.108,0 2,-0.892 2,-2 l 0,-7 z"
-       style="fill:#3c2f1b;fill-opacity:1" />
-    <path
-       sodipodi:nodetypes="ccccccc"
-       inkscape:connector-curvature="0"
-       id="path3761"
-       d="m 2,6 c -2.20338983,2 -3,2 0,2 l 12,0 c 3,0 2.288136,0 0,-2 L 9,1 C 8,0 8,0 7,1 z"
-       style="fill:#3c2f1b;fill-opacity:1;stroke:none" />
-    <path
-       sodipodi:nodetypes="ssccss"
-       inkscape:connector-curvature="0"
-       id="rect3763"
-       d="m 13,1 c 1,0 1,0.446 1,1 l 0,4 -2,0 0,-4 c 0,-0.554 0,-1 1,-1 z"
-       style="fill:#3c2f1b;fill-opacity:1;stroke:none" />
-  </g>
+  <path
+     style="fill:#000000;fill-opacity:0.32156864"
+     d="M 24 20.25 C 23.75 20.25 23.5 20.5 23 21 L 18 26 C 15.79661 28 15 28 18 28 L 18 34 C 18 35.108 18.892 36 20 36 L 22 36 L 22 30 L 26 30 L 26 36 L 28 36 C 29.108 36 30 35.108 30 34 L 30 28 C 33 28 32.288136 28 30 26 L 30 22 C 30 21.446 30 21 29 21 C 28 21 28 21.446 28 22 L 28 24 L 25 21 C 24.5 20.5 24.25 20.25 24 20.25 z "
+     id="rect2989" />
 </svg>

--- a/styles/2/Numix/48x48/places/default-user-home.svg
+++ b/styles/2/Numix/48x48/places/default-user-home.svg
@@ -12,8 +12,8 @@
    height="48"
    id="svg2999"
    version="1.1"
-   inkscape:version="0.48.5 r10040"
-   sodipodi:docname="user-home.svg">
+   inkscape:version="0.91 r"
+   sodipodi:docname="default-user-home.svg">
   <metadata
      id="metadata3017">
     <rdf:RDF>
@@ -36,15 +36,15 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1280"
-     inkscape:window-height="998"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
      id="namedview3013"
      showgrid="true"
      inkscape:zoom="4.9166667"
-     inkscape:cx="7.8270076"
+     inkscape:cx="-37.935704"
      inkscape:cy="55.267371"
      inkscape:window-x="0"
-     inkscape:window-y="0"
+     inkscape:window-y="21"
      inkscape:window-maximized="1"
      inkscape:current-layer="svg2999">
     <inkscape:grid
@@ -62,27 +62,8 @@
      style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#000000;fill-opacity:0.32156863;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
      d="m 6.000023,6.0000005 c -1,0 -2,0.9999995 -2,1.9999995 l 0,2 -1,0 c -1,0 -2.00556897,0.949207 -2,2 l 0,28 c 1.28e-4,1.120734 1.037763,1.9999 2.1875,2 l 41.625,0 c 1.1875,0 2.1875,-1 2.1875,-2 l 0,-25 c 0,-1 -1,-2 -2,-2 l -2,0 0,-5 c 0,-1 -1,-1.9999995 -2,-1.9999995 l -35,0 z m -3,4.9999995 24,0 c 0.507314,0 1,0.494167 1,1 l 0,2 17,0 c 0.540858,0 1,0.471809 1,1 l 0,25 c 0,0.553755 -0.452115,1 -1,1 l -42,0 c -0.512726,0 -1,-0.446246 -1,-1 l 0,-28 c 0,-0.543318 0.479042,-1 1,-1 z"
      id="path3779" />
-  <g
-     id="g4056"
-     transform="translate(16,20)"
-     style="opacity:0.4;fill:#3c2f1b;fill-opacity:1">
-    <path
-       sodipodi:nodetypes="cssccccsscc"
-       inkscape:connector-curvature="0"
-       id="rect2989"
-       d="m 2,7 0,7 c 0,1.108 0.892,2 2,2 l 2,0 0,-6 4,0 0,6 2,0 c 1.108,0 2,-0.892 2,-2 l 0,-7 z"
-       style="fill:#3c2f1b;fill-opacity:1" />
-    <path
-       sodipodi:nodetypes="ccccccc"
-       inkscape:connector-curvature="0"
-       id="path3761"
-       d="m 2,6 c -2.20338983,2 -3,2 0,2 l 12,0 c 3,0 2.288136,0 0,-2 L 9,1 C 8,0 8,0 7,1 z"
-       style="fill:#3c2f1b;fill-opacity:1;stroke:none" />
-    <path
-       sodipodi:nodetypes="ssccss"
-       inkscape:connector-curvature="0"
-       id="rect3763"
-       d="m 13,1 c 1,0 1,0.446 1,1 l 0,4 -2,0 0,-4 c 0,-0.554 0,-1 1,-1 z"
-       style="fill:#3c2f1b;fill-opacity:1;stroke:none" />
-  </g>
+  <path
+     style="fill:#000000;fill-opacity:0.32156864"
+     d="M 24 20.25 C 23.75 20.25 23.5 20.5 23 21 L 18 26 C 15.79661 28 15 28 18 28 L 18 34 C 18 35.108 18.892 36 20 36 L 22 36 L 22 30 L 26 30 L 26 36 L 28 36 C 29.108 36 30 35.108 30 34 L 30 28 C 33 28 32.288136 28 30 26 L 30 22 C 30 21.446 30 21 29 21 C 28 21 28 21.446 28 22 L 28 24 L 25 21 C 24.5 20.5 24.25 20.25 24 20.25 z "
+     id="rect2989" />
 </svg>

--- a/styles/2/Numix/48x48/places/green-user-home.svg
+++ b/styles/2/Numix/48x48/places/green-user-home.svg
@@ -12,8 +12,8 @@
    height="48"
    id="svg2999"
    version="1.1"
-   inkscape:version="0.48.5 r10040"
-   sodipodi:docname="user-home.svg">
+   inkscape:version="0.91 r"
+   sodipodi:docname="green-user-home.svg">
   <metadata
      id="metadata3017">
     <rdf:RDF>
@@ -36,15 +36,15 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1280"
-     inkscape:window-height="998"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
      id="namedview3013"
      showgrid="true"
      inkscape:zoom="4.9166667"
-     inkscape:cx="7.8270076"
+     inkscape:cx="-37.935704"
      inkscape:cy="55.267371"
      inkscape:window-x="0"
-     inkscape:window-y="0"
+     inkscape:window-y="21"
      inkscape:window-maximized="1"
      inkscape:current-layer="svg2999">
     <inkscape:grid
@@ -62,27 +62,8 @@
      style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#000000;fill-opacity:0.32156863;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
      d="m 6.000023,6.0000005 c -1,0 -2,0.9999995 -2,1.9999995 l 0,2 -1,0 c -1,0 -2.00556897,0.949207 -2,2 l 0,28 c 1.28e-4,1.120734 1.037763,1.9999 2.1875,2 l 41.625,0 c 1.1875,0 2.1875,-1 2.1875,-2 l 0,-25 c 0,-1 -1,-2 -2,-2 l -2,0 0,-5 c 0,-1 -1,-1.9999995 -2,-1.9999995 l -35,0 z m -3,4.9999995 24,0 c 0.507314,0 1,0.494167 1,1 l 0,2 17,0 c 0.540858,0 1,0.471809 1,1 l 0,25 c 0,0.553755 -0.452115,1 -1,1 l -42,0 c -0.512726,0 -1,-0.446246 -1,-1 l 0,-28 c 0,-0.543318 0.479042,-1 1,-1 z"
      id="path3779" />
-  <g
-     id="g4056"
-     transform="translate(16,20)"
-     style="opacity:0.4;fill:#3c2f1b;fill-opacity:1">
-    <path
-       sodipodi:nodetypes="cssccccsscc"
-       inkscape:connector-curvature="0"
-       id="rect2989"
-       d="m 2,7 0,7 c 0,1.108 0.892,2 2,2 l 2,0 0,-6 4,0 0,6 2,0 c 1.108,0 2,-0.892 2,-2 l 0,-7 z"
-       style="fill:#3c2f1b;fill-opacity:1" />
-    <path
-       sodipodi:nodetypes="ccccccc"
-       inkscape:connector-curvature="0"
-       id="path3761"
-       d="m 2,6 c -2.20338983,2 -3,2 0,2 l 12,0 c 3,0 2.288136,0 0,-2 L 9,1 C 8,0 8,0 7,1 z"
-       style="fill:#3c2f1b;fill-opacity:1;stroke:none" />
-    <path
-       sodipodi:nodetypes="ssccss"
-       inkscape:connector-curvature="0"
-       id="rect3763"
-       d="m 13,1 c 1,0 1,0.446 1,1 l 0,4 -2,0 0,-4 c 0,-0.554 0,-1 1,-1 z"
-       style="fill:#3c2f1b;fill-opacity:1;stroke:none" />
-  </g>
+  <path
+     style="fill:#000000;fill-opacity:0.32156864"
+     d="M 24 20.25 C 23.75 20.25 23.5 20.5 23 21 L 18 26 C 15.79661 28 15 28 18 28 L 18 34 C 18 35.108 18.892 36 20 36 L 22 36 L 22 30 L 26 30 L 26 36 L 28 36 C 29.108 36 30 35.108 30 34 L 30 28 C 33 28 32.288136 28 30 26 L 30 22 C 30 21.446 30 21 29 21 C 28 21 28 21.446 28 22 L 28 24 L 25 21 C 24.5 20.5 24.25 20.25 24 20.25 z "
+     id="rect2989" />
 </svg>

--- a/styles/2/Numix/48x48/places/grey-user-home.svg
+++ b/styles/2/Numix/48x48/places/grey-user-home.svg
@@ -12,8 +12,8 @@
    height="48"
    id="svg2999"
    version="1.1"
-   inkscape:version="0.48.5 r10040"
-   sodipodi:docname="user-home.svg">
+   inkscape:version="0.91 r"
+   sodipodi:docname="grey-user-home.svg">
   <metadata
      id="metadata3017">
     <rdf:RDF>
@@ -36,15 +36,15 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1280"
-     inkscape:window-height="998"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
      id="namedview3013"
      showgrid="true"
      inkscape:zoom="4.9166667"
-     inkscape:cx="7.8270076"
+     inkscape:cx="-37.935704"
      inkscape:cy="55.267371"
      inkscape:window-x="0"
-     inkscape:window-y="0"
+     inkscape:window-y="21"
      inkscape:window-maximized="1"
      inkscape:current-layer="svg2999">
     <inkscape:grid
@@ -62,27 +62,8 @@
      style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#000000;fill-opacity:0.32156863;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
      d="m 6.000023,6.0000005 c -1,0 -2,0.9999995 -2,1.9999995 l 0,2 -1,0 c -1,0 -2.00556897,0.949207 -2,2 l 0,28 c 1.28e-4,1.120734 1.037763,1.9999 2.1875,2 l 41.625,0 c 1.1875,0 2.1875,-1 2.1875,-2 l 0,-25 c 0,-1 -1,-2 -2,-2 l -2,0 0,-5 c 0,-1 -1,-1.9999995 -2,-1.9999995 l -35,0 z m -3,4.9999995 24,0 c 0.507314,0 1,0.494167 1,1 l 0,2 17,0 c 0.540858,0 1,0.471809 1,1 l 0,25 c 0,0.553755 -0.452115,1 -1,1 l -42,0 c -0.512726,0 -1,-0.446246 -1,-1 l 0,-28 c 0,-0.543318 0.479042,-1 1,-1 z"
      id="path3779" />
-  <g
-     id="g4056"
-     transform="translate(16,20)"
-     style="opacity:0.4;fill:#3c2f1b;fill-opacity:1">
-    <path
-       sodipodi:nodetypes="cssccccsscc"
-       inkscape:connector-curvature="0"
-       id="rect2989"
-       d="m 2,7 0,7 c 0,1.108 0.892,2 2,2 l 2,0 0,-6 4,0 0,6 2,0 c 1.108,0 2,-0.892 2,-2 l 0,-7 z"
-       style="fill:#3c2f1b;fill-opacity:1" />
-    <path
-       sodipodi:nodetypes="ccccccc"
-       inkscape:connector-curvature="0"
-       id="path3761"
-       d="m 2,6 c -2.20338983,2 -3,2 0,2 l 12,0 c 3,0 2.288136,0 0,-2 L 9,1 C 8,0 8,0 7,1 z"
-       style="fill:#3c2f1b;fill-opacity:1;stroke:none" />
-    <path
-       sodipodi:nodetypes="ssccss"
-       inkscape:connector-curvature="0"
-       id="rect3763"
-       d="m 13,1 c 1,0 1,0.446 1,1 l 0,4 -2,0 0,-4 c 0,-0.554 0,-1 1,-1 z"
-       style="fill:#3c2f1b;fill-opacity:1;stroke:none" />
-  </g>
+  <path
+     style="fill:#000000;fill-opacity:0.32156864"
+     d="M 24 20.25 C 23.75 20.25 23.5 20.5 23 21 L 18 26 C 15.79661 28 15 28 18 28 L 18 34 C 18 35.108 18.892 36 20 36 L 22 36 L 22 30 L 26 30 L 26 36 L 28 36 C 29.108 36 30 35.108 30 34 L 30 28 C 33 28 32.288136 28 30 26 L 30 22 C 30 21.446 30 21 29 21 C 28 21 28 21.446 28 22 L 28 24 L 25 21 C 24.5 20.5 24.25 20.25 24 20.25 z "
+     id="rect2989" />
 </svg>

--- a/styles/2/Numix/48x48/places/orange-user-home.svg
+++ b/styles/2/Numix/48x48/places/orange-user-home.svg
@@ -12,8 +12,8 @@
    height="48"
    id="svg2999"
    version="1.1"
-   inkscape:version="0.48.5 r10040"
-   sodipodi:docname="user-home.svg">
+   inkscape:version="0.91 r"
+   sodipodi:docname="orange-user-home.svg">
   <metadata
      id="metadata3017">
     <rdf:RDF>
@@ -36,15 +36,15 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1280"
-     inkscape:window-height="998"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
      id="namedview3013"
      showgrid="true"
      inkscape:zoom="4.9166667"
-     inkscape:cx="7.8270076"
+     inkscape:cx="-37.935704"
      inkscape:cy="55.267371"
      inkscape:window-x="0"
-     inkscape:window-y="0"
+     inkscape:window-y="21"
      inkscape:window-maximized="1"
      inkscape:current-layer="svg2999">
     <inkscape:grid
@@ -62,27 +62,8 @@
      style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#000000;fill-opacity:0.32156863;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
      d="m 6.000023,6.0000005 c -1,0 -2,0.9999995 -2,1.9999995 l 0,2 -1,0 c -1,0 -2.00556897,0.949207 -2,2 l 0,28 c 1.28e-4,1.120734 1.037763,1.9999 2.1875,2 l 41.625,0 c 1.1875,0 2.1875,-1 2.1875,-2 l 0,-25 c 0,-1 -1,-2 -2,-2 l -2,0 0,-5 c 0,-1 -1,-1.9999995 -2,-1.9999995 l -35,0 z m -3,4.9999995 24,0 c 0.507314,0 1,0.494167 1,1 l 0,2 17,0 c 0.540858,0 1,0.471809 1,1 l 0,25 c 0,0.553755 -0.452115,1 -1,1 l -42,0 c -0.512726,0 -1,-0.446246 -1,-1 l 0,-28 c 0,-0.543318 0.479042,-1 1,-1 z"
      id="path3779" />
-  <g
-     id="g4056"
-     transform="translate(16,20)"
-     style="opacity:0.4;fill:#3c2f1b;fill-opacity:1">
-    <path
-       sodipodi:nodetypes="cssccccsscc"
-       inkscape:connector-curvature="0"
-       id="rect2989"
-       d="m 2,7 0,7 c 0,1.108 0.892,2 2,2 l 2,0 0,-6 4,0 0,6 2,0 c 1.108,0 2,-0.892 2,-2 l 0,-7 z"
-       style="fill:#3c2f1b;fill-opacity:1" />
-    <path
-       sodipodi:nodetypes="ccccccc"
-       inkscape:connector-curvature="0"
-       id="path3761"
-       d="m 2,6 c -2.20338983,2 -3,2 0,2 l 12,0 c 3,0 2.288136,0 0,-2 L 9,1 C 8,0 8,0 7,1 z"
-       style="fill:#3c2f1b;fill-opacity:1;stroke:none" />
-    <path
-       sodipodi:nodetypes="ssccss"
-       inkscape:connector-curvature="0"
-       id="rect3763"
-       d="m 13,1 c 1,0 1,0.446 1,1 l 0,4 -2,0 0,-4 c 0,-0.554 0,-1 1,-1 z"
-       style="fill:#3c2f1b;fill-opacity:1;stroke:none" />
-  </g>
+  <path
+     style="fill:#000000;fill-opacity:0.32156864"
+     d="M 24 20.25 C 23.75 20.25 23.5 20.5 23 21 L 18 26 C 15.79661 28 15 28 18 28 L 18 34 C 18 35.108 18.892 36 20 36 L 22 36 L 22 30 L 26 30 L 26 36 L 28 36 C 29.108 36 30 35.108 30 34 L 30 28 C 33 28 32.288136 28 30 26 L 30 22 C 30 21.446 30 21 29 21 C 28 21 28 21.446 28 22 L 28 24 L 25 21 C 24.5 20.5 24.25 20.25 24 20.25 z "
+     id="rect2989" />
 </svg>

--- a/styles/2/Numix/48x48/places/pink-user-home.svg
+++ b/styles/2/Numix/48x48/places/pink-user-home.svg
@@ -12,8 +12,8 @@
    height="48"
    id="svg2999"
    version="1.1"
-   inkscape:version="0.48.5 r10040"
-   sodipodi:docname="user-home.svg">
+   inkscape:version="0.91 r"
+   sodipodi:docname="pink-user-home.svg">
   <metadata
      id="metadata3017">
     <rdf:RDF>
@@ -36,15 +36,15 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1280"
-     inkscape:window-height="998"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
      id="namedview3013"
      showgrid="true"
-     inkscape:zoom="4.9166667"
-     inkscape:cx="7.8270076"
-     inkscape:cy="55.267371"
+     inkscape:zoom="9.8333333"
+     inkscape:cx="12.4244"
+     inkscape:cy="21.671762"
      inkscape:window-x="0"
-     inkscape:window-y="0"
+     inkscape:window-y="21"
      inkscape:window-maximized="1"
      inkscape:current-layer="svg2999">
     <inkscape:grid
@@ -62,27 +62,8 @@
      style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#000000;fill-opacity:0.32156863;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
      d="m 6.000023,6.0000005 c -1,0 -2,0.9999995 -2,1.9999995 l 0,2 -1,0 c -1,0 -2.00556897,0.949207 -2,2 l 0,28 c 1.28e-4,1.120734 1.037763,1.9999 2.1875,2 l 41.625,0 c 1.1875,0 2.1875,-1 2.1875,-2 l 0,-25 c 0,-1 -1,-2 -2,-2 l -2,0 0,-5 c 0,-1 -1,-1.9999995 -2,-1.9999995 l -35,0 z m -3,4.9999995 24,0 c 0.507314,0 1,0.494167 1,1 l 0,2 17,0 c 0.540858,0 1,0.471809 1,1 l 0,25 c 0,0.553755 -0.452115,1 -1,1 l -42,0 c -0.512726,0 -1,-0.446246 -1,-1 l 0,-28 c 0,-0.543318 0.479042,-1 1,-1 z"
      id="path3779" />
-  <g
-     id="g4056"
-     transform="translate(16,20)"
-     style="opacity:0.4;fill:#3c2f1b;fill-opacity:1">
-    <path
-       sodipodi:nodetypes="cssccccsscc"
-       inkscape:connector-curvature="0"
-       id="rect2989"
-       d="m 2,7 0,7 c 0,1.108 0.892,2 2,2 l 2,0 0,-6 4,0 0,6 2,0 c 1.108,0 2,-0.892 2,-2 l 0,-7 z"
-       style="fill:#3c2f1b;fill-opacity:1" />
-    <path
-       sodipodi:nodetypes="ccccccc"
-       inkscape:connector-curvature="0"
-       id="path3761"
-       d="m 2,6 c -2.20338983,2 -3,2 0,2 l 12,0 c 3,0 2.288136,0 0,-2 L 9,1 C 8,0 8,0 7,1 z"
-       style="fill:#3c2f1b;fill-opacity:1;stroke:none" />
-    <path
-       sodipodi:nodetypes="ssccss"
-       inkscape:connector-curvature="0"
-       id="rect3763"
-       d="m 13,1 c 1,0 1,0.446 1,1 l 0,4 -2,0 0,-4 c 0,-0.554 0,-1 1,-1 z"
-       style="fill:#3c2f1b;fill-opacity:1;stroke:none" />
-  </g>
+  <path
+     style="fill:#000000;fill-opacity:0.32156864"
+     d="M 24 20.25 C 23.75 20.25 23.5 20.5 23 21 L 18 26 C 15.79661 28 15 28 18 28 L 18 34 C 18 35.108 18.892 36 20 36 L 22 36 L 22 30 L 26 30 L 26 36 L 28 36 C 29.108 36 30 35.108 30 34 L 30 28 C 33 28 32.288136 28 30 26 L 30 22 C 30 21.446 30 21 29 21 C 28 21 28 21.446 28 22 L 28 24 L 25 21 C 24.5 20.5 24.25 20.25 24 20.25 z "
+     id="rect2989" />
 </svg>

--- a/styles/2/Numix/48x48/places/purple-user-home.svg
+++ b/styles/2/Numix/48x48/places/purple-user-home.svg
@@ -12,8 +12,8 @@
    height="48"
    id="svg2999"
    version="1.1"
-   inkscape:version="0.48.5 r10040"
-   sodipodi:docname="user-home.svg">
+   inkscape:version="0.91 r"
+   sodipodi:docname="purple-user-home.svg">
   <metadata
      id="metadata3017">
     <rdf:RDF>
@@ -36,15 +36,15 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1280"
-     inkscape:window-height="998"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
      id="namedview3013"
      showgrid="true"
-     inkscape:zoom="4.9166667"
-     inkscape:cx="7.8270076"
-     inkscape:cy="55.267371"
+     inkscape:zoom="13.906433"
+     inkscape:cx="8.2885763"
+     inkscape:cy="25.268901"
      inkscape:window-x="0"
-     inkscape:window-y="0"
+     inkscape:window-y="21"
      inkscape:window-maximized="1"
      inkscape:current-layer="svg2999">
     <inkscape:grid
@@ -62,27 +62,8 @@
      style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#000000;fill-opacity:0.32156863;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
      d="m 6.000023,6.0000005 c -1,0 -2,0.9999995 -2,1.9999995 l 0,2 -1,0 c -1,0 -2.00556897,0.949207 -2,2 l 0,28 c 1.28e-4,1.120734 1.037763,1.9999 2.1875,2 l 41.625,0 c 1.1875,0 2.1875,-1 2.1875,-2 l 0,-25 c 0,-1 -1,-2 -2,-2 l -2,0 0,-5 c 0,-1 -1,-1.9999995 -2,-1.9999995 l -35,0 z m -3,4.9999995 24,0 c 0.507314,0 1,0.494167 1,1 l 0,2 17,0 c 0.540858,0 1,0.471809 1,1 l 0,25 c 0,0.553755 -0.452115,1 -1,1 l -42,0 c -0.512726,0 -1,-0.446246 -1,-1 l 0,-28 c 0,-0.543318 0.479042,-1 1,-1 z"
      id="path3779" />
-  <g
-     id="g4056"
-     transform="translate(16,20)"
-     style="opacity:0.4;fill:#3c2f1b;fill-opacity:1">
-    <path
-       sodipodi:nodetypes="cssccccsscc"
-       inkscape:connector-curvature="0"
-       id="rect2989"
-       d="m 2,7 0,7 c 0,1.108 0.892,2 2,2 l 2,0 0,-6 4,0 0,6 2,0 c 1.108,0 2,-0.892 2,-2 l 0,-7 z"
-       style="fill:#3c2f1b;fill-opacity:1" />
-    <path
-       sodipodi:nodetypes="ccccccc"
-       inkscape:connector-curvature="0"
-       id="path3761"
-       d="m 2,6 c -2.20338983,2 -3,2 0,2 l 12,0 c 3,0 2.288136,0 0,-2 L 9,1 C 8,0 8,0 7,1 z"
-       style="fill:#3c2f1b;fill-opacity:1;stroke:none" />
-    <path
-       sodipodi:nodetypes="ssccss"
-       inkscape:connector-curvature="0"
-       id="rect3763"
-       d="m 13,1 c 1,0 1,0.446 1,1 l 0,4 -2,0 0,-4 c 0,-0.554 0,-1 1,-1 z"
-       style="fill:#3c2f1b;fill-opacity:1;stroke:none" />
-  </g>
+  <path
+     style="fill:#000000;fill-opacity:0.32156864"
+     d="M 24 20.25 C 23.75 20.25 23.5 20.5 23 21 L 18 26 C 15.79661 28 15 28 18 28 L 18 34 C 18 35.108 18.892 36 20 36 L 22 36 L 22 30 L 26 30 L 26 36 L 28 36 C 29.108 36 30 35.108 30 34 L 30 28 C 33 28 32.288136 28 30 26 L 30 22 C 30 21.446 30 21 29 21 C 28 21 28 21.446 28 22 L 28 24 L 25 21 C 24.5 20.5 24.25 20.25 24 20.25 z "
+     id="rect2989" />
 </svg>

--- a/styles/2/Numix/48x48/places/red-user-home.svg
+++ b/styles/2/Numix/48x48/places/red-user-home.svg
@@ -12,8 +12,8 @@
    height="48"
    id="svg2999"
    version="1.1"
-   inkscape:version="0.48.5 r10040"
-   sodipodi:docname="user-home.svg">
+   inkscape:version="0.91 r"
+   sodipodi:docname="red-user-home.svg">
   <metadata
      id="metadata3017">
     <rdf:RDF>
@@ -36,15 +36,15 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1280"
-     inkscape:window-height="998"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
      id="namedview3013"
      showgrid="true"
      inkscape:zoom="4.9166667"
-     inkscape:cx="7.8270076"
-     inkscape:cy="55.267371"
+     inkscape:cx="-0.049857879"
+     inkscape:cy="18.81838"
      inkscape:window-x="0"
-     inkscape:window-y="0"
+     inkscape:window-y="21"
      inkscape:window-maximized="1"
      inkscape:current-layer="svg2999">
     <inkscape:grid
@@ -62,27 +62,8 @@
      style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#000000;fill-opacity:0.32156863;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
      d="m 6.000023,6.0000005 c -1,0 -2,0.9999995 -2,1.9999995 l 0,2 -1,0 c -1,0 -2.00556897,0.949207 -2,2 l 0,28 c 1.28e-4,1.120734 1.037763,1.9999 2.1875,2 l 41.625,0 c 1.1875,0 2.1875,-1 2.1875,-2 l 0,-25 c 0,-1 -1,-2 -2,-2 l -2,0 0,-5 c 0,-1 -1,-1.9999995 -2,-1.9999995 l -35,0 z m -3,4.9999995 24,0 c 0.507314,0 1,0.494167 1,1 l 0,2 17,0 c 0.540858,0 1,0.471809 1,1 l 0,25 c 0,0.553755 -0.452115,1 -1,1 l -42,0 c -0.512726,0 -1,-0.446246 -1,-1 l 0,-28 c 0,-0.543318 0.479042,-1 1,-1 z"
      id="path3779" />
-  <g
-     id="g4056"
-     transform="translate(16,20)"
-     style="opacity:0.4;fill:#3c2f1b;fill-opacity:1">
-    <path
-       sodipodi:nodetypes="cssccccsscc"
-       inkscape:connector-curvature="0"
-       id="rect2989"
-       d="m 2,7 0,7 c 0,1.108 0.892,2 2,2 l 2,0 0,-6 4,0 0,6 2,0 c 1.108,0 2,-0.892 2,-2 l 0,-7 z"
-       style="fill:#3c2f1b;fill-opacity:1" />
-    <path
-       sodipodi:nodetypes="ccccccc"
-       inkscape:connector-curvature="0"
-       id="path3761"
-       d="m 2,6 c -2.20338983,2 -3,2 0,2 l 12,0 c 3,0 2.288136,0 0,-2 L 9,1 C 8,0 8,0 7,1 z"
-       style="fill:#3c2f1b;fill-opacity:1;stroke:none" />
-    <path
-       sodipodi:nodetypes="ssccss"
-       inkscape:connector-curvature="0"
-       id="rect3763"
-       d="m 13,1 c 1,0 1,0.446 1,1 l 0,4 -2,0 0,-4 c 0,-0.554 0,-1 1,-1 z"
-       style="fill:#3c2f1b;fill-opacity:1;stroke:none" />
-  </g>
+  <path
+     style="fill:#000000;fill-opacity:0.32156864"
+     d="M 24 20.25 C 23.75 20.25 23.5 20.5 23 21 L 18 26 C 15.79661 28 15 28 18 28 L 18 34 C 18 35.108 18.892 36 20 36 L 22 36 L 22 30 L 26 30 L 26 36 L 28 36 C 29.108 36 30 35.108 30 34 L 30 28 C 33 28 32.288136 28 30 26 L 30 22 C 30 21.446 30 21 29 21 C 28 21 28 21.446 28 22 L 28 24 L 25 21 C 24.5 20.5 24.25 20.25 24 20.25 z "
+     id="rect2989" />
 </svg>

--- a/styles/2/Numix/48x48/places/yellow-user-home.svg
+++ b/styles/2/Numix/48x48/places/yellow-user-home.svg
@@ -12,8 +12,8 @@
    height="48"
    id="svg2999"
    version="1.1"
-   inkscape:version="0.48.5 r10040"
-   sodipodi:docname="user-home.svg">
+   inkscape:version="0.91 r"
+   sodipodi:docname="yellow-user-home.svg">
   <metadata
      id="metadata3017">
     <rdf:RDF>
@@ -36,15 +36,15 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1280"
-     inkscape:window-height="998"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
      id="namedview3013"
      showgrid="true"
      inkscape:zoom="4.9166667"
-     inkscape:cx="7.8270076"
-     inkscape:cy="55.267371"
+     inkscape:cx="-9.6843577"
+     inkscape:cy="38.506736"
      inkscape:window-x="0"
-     inkscape:window-y="0"
+     inkscape:window-y="21"
      inkscape:window-maximized="1"
      inkscape:current-layer="svg2999">
     <inkscape:grid
@@ -62,27 +62,8 @@
      style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#000000;fill-opacity:0.32156863;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
      d="m 6.000023,6.0000005 c -1,0 -2,0.9999995 -2,1.9999995 l 0,2 -1,0 c -1,0 -2.00556897,0.949207 -2,2 l 0,28 c 1.28e-4,1.120734 1.037763,1.9999 2.1875,2 l 41.625,0 c 1.1875,0 2.1875,-1 2.1875,-2 l 0,-25 c 0,-1 -1,-2 -2,-2 l -2,0 0,-5 c 0,-1 -1,-1.9999995 -2,-1.9999995 l -35,0 z m -3,4.9999995 24,0 c 0.507314,0 1,0.494167 1,1 l 0,2 17,0 c 0.540858,0 1,0.471809 1,1 l 0,25 c 0,0.553755 -0.452115,1 -1,1 l -42,0 c -0.512726,0 -1,-0.446246 -1,-1 l 0,-28 c 0,-0.543318 0.479042,-1 1,-1 z"
      id="path3779" />
-  <g
-     id="g4056"
-     transform="translate(16,20)"
-     style="opacity:0.4;fill:#3c2f1b;fill-opacity:1">
-    <path
-       sodipodi:nodetypes="cssccccsscc"
-       inkscape:connector-curvature="0"
-       id="rect2989"
-       d="m 2,7 0,7 c 0,1.108 0.892,2 2,2 l 2,0 0,-6 4,0 0,6 2,0 c 1.108,0 2,-0.892 2,-2 l 0,-7 z"
-       style="fill:#3c2f1b;fill-opacity:1" />
-    <path
-       sodipodi:nodetypes="ccccccc"
-       inkscape:connector-curvature="0"
-       id="path3761"
-       d="m 2,6 c -2.20338983,2 -3,2 0,2 l 12,0 c 3,0 2.288136,0 0,-2 L 9,1 C 8,0 8,0 7,1 z"
-       style="fill:#3c2f1b;fill-opacity:1;stroke:none" />
-    <path
-       sodipodi:nodetypes="ssccss"
-       inkscape:connector-curvature="0"
-       id="rect3763"
-       d="m 13,1 c 1,0 1,0.446 1,1 l 0,4 -2,0 0,-4 c 0,-0.554 0,-1 1,-1 z"
-       style="fill:#3c2f1b;fill-opacity:1;stroke:none" />
-  </g>
+  <path
+     style="fill:#000000;fill-opacity:0.32156864"
+     d="M 24 20.25 C 23.75 20.25 23.5 20.5 23 21 L 18 26 C 15.79661 28 15 28 18 28 L 18 34 C 18 35.108 18.892 36 20 36 L 22 36 L 22 30 L 26 30 L 26 36 L 28 36 C 29.108 36 30 35.108 30 34 L 30 28 C 33 28 32.288136 28 30 26 L 30 22 C 30 21.446 30 21 29 21 C 28 21 28 21.446 28 22 L 28 24 L 25 21 C 24.5 20.5 24.25 20.25 24 20.25 z "
+     id="rect2989" />
 </svg>

--- a/styles/2/Numix/96x96/places/blue-user-home.svg
+++ b/styles/2/Numix/96x96/places/blue-user-home.svg
@@ -12,8 +12,8 @@
    height="96"
    id="svg2999"
    version="1.1"
-   inkscape:version="0.48.5 r10040"
-   sodipodi:docname="user-home.svg">
+   inkscape:version="0.91 r"
+   sodipodi:docname="blue-user-home.svg">
   <metadata
      id="metadata3017">
     <rdf:RDF>
@@ -36,15 +36,15 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1280"
-     inkscape:window-height="998"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
      id="namedview3013"
      showgrid="true"
-     inkscape:zoom="9.8333333"
-     inkscape:cx="39.012102"
-     inkscape:cy="31.622922"
+     inkscape:zoom="3.4766083"
+     inkscape:cx="-28.765308"
+     inkscape:cy="19.518264"
      inkscape:window-x="0"
-     inkscape:window-y="0"
+     inkscape:window-y="21"
      inkscape:window-maximized="1"
      inkscape:current-layer="svg2999">
     <inkscape:grid
@@ -66,27 +66,8 @@
      style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#000000;fill-opacity:0.32156863;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
      d="m 12.000041,12.000037 c -1.999999,0 -3.999998,1.999998 -3.999998,3.999997 l 0,3.999998 -1.999999,0 c -1.999999,0 -4.0111358,1.898413 -3.999998,3.999998 l 0,55.999972 C 2.000302,82.241469 4.075571,83.9998 6.3750438,84 L 89.625002,84 C 92.000001,84 94,82.000001 94,80.000002 l 0,-49.999975 c 0,-1.999999 -1.999999,-3.999998 -3.999998,-3.999998 l -3.999998,0 0,-9.999995 c 0,-1.999999 -1.999999,-3.999997 -3.999998,-3.999997 l -69.999965,0 z m -5.999997,9.999994 47.999976,0 c 1.014627,0 1.999999,0.988334 1.999999,1.999999 l 0,3.999998 33.999983,0 c 1.081715,0 1.999999,0.943618 1.999999,1.999999 l 0,49.999975 c 0,1.107509 -0.90423,1.999999 -1.999999,1.999999 l -83.999958,0 c -1.0254515,0 -1.999999,-0.892492 -1.999999,-1.999999 l 0,-55.999972 c 0,-1.086635 0.9580835,-1.999999 1.999999,-1.999999 z"
      id="path3779" />
-  <g
-     id="g4056"
-     transform="matrix(1.999999,0,0,1.999999,31.999985,40.000022)"
-     style="opacity:0.4;fill:#3c2f1b;fill-opacity:1">
-    <path
-       sodipodi:nodetypes="cssccccsscc"
-       inkscape:connector-curvature="0"
-       id="rect2989"
-       d="m 2,7 0,7 c 0,1.108 0.892,2 2,2 l 2,0 0,-6 4,0 0,6 2,0 c 1.108,0 2,-0.892 2,-2 l 0,-7 z"
-       style="fill:#3c2f1b;fill-opacity:1" />
-    <path
-       sodipodi:nodetypes="ccccccc"
-       inkscape:connector-curvature="0"
-       id="path3761"
-       d="m 2,6 c -2.20338983,2 -3,2 0,2 l 12,0 c 3,0 2.288136,0 0,-2 L 9,1 C 8,0 8,0 7,1 z"
-       style="fill:#3c2f1b;fill-opacity:1;stroke:none" />
-    <path
-       sodipodi:nodetypes="ssccss"
-       inkscape:connector-curvature="0"
-       id="rect3763"
-       d="m 13,1 c 1,0 1,0.446 1,1 l 0,4 -2,0 0,-4 c 0,-0.554 0,-1 1,-1 z"
-       style="fill:#3c2f1b;fill-opacity:1;stroke:none" />
-  </g>
+  <path
+     style="fill:#000000;fill-opacity:0.32156863"
+     d="M 48 40.5 C 47.5 40.5 47 41 46 42 L 36 52 C 31.593223 55.999998 30.000003 56 36 56 L 36 68 C 36 70.215999 37.784001 72 40 72 L 44 72 L 44 60 L 52 60 L 52 72 L 56 72 C 58.215999 72 60 70.215999 60 68 L 60 56 C 65.999997 56 64.57627 55.999998 60 52 L 60 44 C 60 42.892001 59.999999 42 58 42 C 56.000001 42 56 42.892001 56 44 L 56 48 L 50 42 C 49 41 48.5 40.5 48 40.5 z "
+     id="rect2989" />
 </svg>

--- a/styles/2/Numix/96x96/places/brown-user-home.svg
+++ b/styles/2/Numix/96x96/places/brown-user-home.svg
@@ -12,8 +12,8 @@
    height="96"
    id="svg2999"
    version="1.1"
-   inkscape:version="0.48.5 r10040"
-   sodipodi:docname="user-home.svg">
+   inkscape:version="0.91 r"
+   sodipodi:docname="brown-user-home.svg">
   <metadata
      id="metadata3017">
     <rdf:RDF>
@@ -36,15 +36,15 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1280"
-     inkscape:window-height="998"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
      id="namedview3013"
      showgrid="true"
-     inkscape:zoom="9.8333333"
-     inkscape:cx="39.012102"
-     inkscape:cy="31.622922"
+     inkscape:zoom="6.9532167"
+     inkscape:cx="12.257569"
+     inkscape:cy="53.416576"
      inkscape:window-x="0"
-     inkscape:window-y="0"
+     inkscape:window-y="21"
      inkscape:window-maximized="1"
      inkscape:current-layer="svg2999">
     <inkscape:grid
@@ -66,27 +66,8 @@
      style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#000000;fill-opacity:0.32156863;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
      d="m 12.000041,12.000037 c -1.999999,0 -3.999998,1.999998 -3.999998,3.999997 l 0,3.999998 -1.999999,0 c -1.999999,0 -4.0111358,1.898413 -3.999998,3.999998 l 0,55.999972 C 2.000302,82.241469 4.075571,83.9998 6.3750438,84 L 89.625002,84 C 92.000001,84 94,82.000001 94,80.000002 l 0,-49.999975 c 0,-1.999999 -1.999999,-3.999998 -3.999998,-3.999998 l -3.999998,0 0,-9.999995 c 0,-1.999999 -1.999999,-3.999997 -3.999998,-3.999997 l -69.999965,0 z m -5.999997,9.999994 47.999976,0 c 1.014627,0 1.999999,0.988334 1.999999,1.999999 l 0,3.999998 33.999983,0 c 1.081715,0 1.999999,0.943618 1.999999,1.999999 l 0,49.999975 c 0,1.107509 -0.90423,1.999999 -1.999999,1.999999 l -83.999958,0 c -1.0254515,0 -1.999999,-0.892492 -1.999999,-1.999999 l 0,-55.999972 c 0,-1.086635 0.9580835,-1.999999 1.999999,-1.999999 z"
      id="path3779" />
-  <g
-     id="g4056"
-     transform="matrix(1.999999,0,0,1.999999,31.999985,40.000022)"
-     style="opacity:0.4;fill:#3c2f1b;fill-opacity:1">
-    <path
-       sodipodi:nodetypes="cssccccsscc"
-       inkscape:connector-curvature="0"
-       id="rect2989"
-       d="m 2,7 0,7 c 0,1.108 0.892,2 2,2 l 2,0 0,-6 4,0 0,6 2,0 c 1.108,0 2,-0.892 2,-2 l 0,-7 z"
-       style="fill:#3c2f1b;fill-opacity:1" />
-    <path
-       sodipodi:nodetypes="ccccccc"
-       inkscape:connector-curvature="0"
-       id="path3761"
-       d="m 2,6 c -2.20338983,2 -3,2 0,2 l 12,0 c 3,0 2.288136,0 0,-2 L 9,1 C 8,0 8,0 7,1 z"
-       style="fill:#3c2f1b;fill-opacity:1;stroke:none" />
-    <path
-       sodipodi:nodetypes="ssccss"
-       inkscape:connector-curvature="0"
-       id="rect3763"
-       d="m 13,1 c 1,0 1,0.446 1,1 l 0,4 -2,0 0,-4 c 0,-0.554 0,-1 1,-1 z"
-       style="fill:#3c2f1b;fill-opacity:1;stroke:none" />
-  </g>
+  <path
+     style="fill:#000000;fill-opacity:0.32156864"
+     d="M 48 40.5 C 47.5 40.5 47 41 46 42 L 36 52 C 31.593223 55.999998 30.000003 56 36 56 L 36 68 C 36 70.215999 37.784001 72 40 72 L 44 72 L 44 60 L 52 60 L 52 72 L 56 72 C 58.215999 72 60 70.215999 60 68 L 60 56 C 65.999997 56 64.57627 55.999998 60 52 L 60 44 C 60 42.892001 59.999999 42 58 42 C 56.000001 42 56 42.892001 56 44 L 56 48 L 50 42 C 49 41 48.5 40.5 48 40.5 z "
+     id="rect2989" />
 </svg>

--- a/styles/2/Numix/96x96/places/default-user-home.svg
+++ b/styles/2/Numix/96x96/places/default-user-home.svg
@@ -12,8 +12,8 @@
    height="96"
    id="svg2999"
    version="1.1"
-   inkscape:version="0.48.5 r10040"
-   sodipodi:docname="user-home.svg">
+   inkscape:version="0.91 r"
+   sodipodi:docname="default-user-home.svg">
   <metadata
      id="metadata3017">
     <rdf:RDF>
@@ -36,15 +36,15 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1280"
-     inkscape:window-height="998"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
      id="namedview3013"
      showgrid="true"
-     inkscape:zoom="9.8333333"
-     inkscape:cx="39.012102"
-     inkscape:cy="31.622922"
+     inkscape:zoom="3.4766083"
+     inkscape:cx="63.911161"
+     inkscape:cy="17.425272"
      inkscape:window-x="0"
-     inkscape:window-y="0"
+     inkscape:window-y="21"
      inkscape:window-maximized="1"
      inkscape:current-layer="svg2999">
     <inkscape:grid
@@ -66,27 +66,8 @@
      style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#000000;fill-opacity:0.32156863;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
      d="m 12.000041,12.000037 c -1.999999,0 -3.999998,1.999998 -3.999998,3.999997 l 0,3.999998 -1.999999,0 c -1.999999,0 -4.0111358,1.898413 -3.999998,3.999998 l 0,55.999972 C 2.000302,82.241469 4.075571,83.9998 6.3750438,84 L 89.625002,84 C 92.000001,84 94,82.000001 94,80.000002 l 0,-49.999975 c 0,-1.999999 -1.999999,-3.999998 -3.999998,-3.999998 l -3.999998,0 0,-9.999995 c 0,-1.999999 -1.999999,-3.999997 -3.999998,-3.999997 l -69.999965,0 z m -5.999997,9.999994 47.999976,0 c 1.014627,0 1.999999,0.988334 1.999999,1.999999 l 0,3.999998 33.999983,0 c 1.081715,0 1.999999,0.943618 1.999999,1.999999 l 0,49.999975 c 0,1.107509 -0.90423,1.999999 -1.999999,1.999999 l -83.999958,0 c -1.0254515,0 -1.999999,-0.892492 -1.999999,-1.999999 l 0,-55.999972 c 0,-1.086635 0.9580835,-1.999999 1.999999,-1.999999 z"
      id="path3779" />
-  <g
-     id="g4056"
-     transform="matrix(1.999999,0,0,1.999999,31.999985,40.000022)"
-     style="opacity:0.4;fill:#3c2f1b;fill-opacity:1">
-    <path
-       sodipodi:nodetypes="cssccccsscc"
-       inkscape:connector-curvature="0"
-       id="rect2989"
-       d="m 2,7 0,7 c 0,1.108 0.892,2 2,2 l 2,0 0,-6 4,0 0,6 2,0 c 1.108,0 2,-0.892 2,-2 l 0,-7 z"
-       style="fill:#3c2f1b;fill-opacity:1" />
-    <path
-       sodipodi:nodetypes="ccccccc"
-       inkscape:connector-curvature="0"
-       id="path3761"
-       d="m 2,6 c -2.20338983,2 -3,2 0,2 l 12,0 c 3,0 2.288136,0 0,-2 L 9,1 C 8,0 8,0 7,1 z"
-       style="fill:#3c2f1b;fill-opacity:1;stroke:none" />
-    <path
-       sodipodi:nodetypes="ssccss"
-       inkscape:connector-curvature="0"
-       id="rect3763"
-       d="m 13,1 c 1,0 1,0.446 1,1 l 0,4 -2,0 0,-4 c 0,-0.554 0,-1 1,-1 z"
-       style="fill:#3c2f1b;fill-opacity:1;stroke:none" />
-  </g>
+  <path
+     style="fill:#000000;fill-opacity:0.32156863"
+     d="M 48 40.5 C 47.5 40.5 47 41 46 42 L 36 52 C 31.593223 55.999998 30.000003 56 36 56 L 36 68 C 36 70.215999 37.784001 72 40 72 L 44 72 L 44 60 L 52 60 L 52 72 L 56 72 C 58.215999 72 60 70.215999 60 68 L 60 56 C 65.999997 56 64.57627 55.999998 60 52 L 60 44 C 60 42.892001 59.999999 42 58 42 C 56.000001 42 56 42.892001 56 44 L 56 48 L 50 42 C 49 41 48.5 40.5 48 40.5 z "
+     id="rect2989" />
 </svg>

--- a/styles/2/Numix/96x96/places/green-user-home.svg
+++ b/styles/2/Numix/96x96/places/green-user-home.svg
@@ -12,8 +12,8 @@
    height="96"
    id="svg2999"
    version="1.1"
-   inkscape:version="0.48.5 r10040"
-   sodipodi:docname="user-home.svg">
+   inkscape:version="0.91 r"
+   sodipodi:docname="green-user-home.svg">
   <metadata
      id="metadata3017">
     <rdf:RDF>
@@ -36,15 +36,15 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1280"
-     inkscape:window-height="998"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
      id="namedview3013"
      showgrid="true"
      inkscape:zoom="9.8333333"
-     inkscape:cx="39.012102"
+     inkscape:cx="16.130746"
      inkscape:cy="31.622922"
      inkscape:window-x="0"
-     inkscape:window-y="0"
+     inkscape:window-y="21"
      inkscape:window-maximized="1"
      inkscape:current-layer="svg2999">
     <inkscape:grid
@@ -66,27 +66,8 @@
      style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#000000;fill-opacity:0.32156863;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
      d="m 12.000041,12.000037 c -1.999999,0 -3.999998,1.999998 -3.999998,3.999997 l 0,3.999998 -1.999999,0 c -1.999999,0 -4.0111358,1.898413 -3.999998,3.999998 l 0,55.999972 C 2.000302,82.241469 4.075571,83.9998 6.3750438,84 L 89.625002,84 C 92.000001,84 94,82.000001 94,80.000002 l 0,-49.999975 c 0,-1.999999 -1.999999,-3.999998 -3.999998,-3.999998 l -3.999998,0 0,-9.999995 c 0,-1.999999 -1.999999,-3.999997 -3.999998,-3.999997 l -69.999965,0 z m -5.999997,9.999994 47.999976,0 c 1.014627,0 1.999999,0.988334 1.999999,1.999999 l 0,3.999998 33.999983,0 c 1.081715,0 1.999999,0.943618 1.999999,1.999999 l 0,49.999975 c 0,1.107509 -0.90423,1.999999 -1.999999,1.999999 l -83.999958,0 c -1.0254515,0 -1.999999,-0.892492 -1.999999,-1.999999 l 0,-55.999972 c 0,-1.086635 0.9580835,-1.999999 1.999999,-1.999999 z"
      id="path3779" />
-  <g
-     id="g4056"
-     transform="matrix(1.999999,0,0,1.999999,31.999985,40.000022)"
-     style="opacity:0.4;fill:#3c2f1b;fill-opacity:1">
-    <path
-       sodipodi:nodetypes="cssccccsscc"
-       inkscape:connector-curvature="0"
-       id="rect2989"
-       d="m 2,7 0,7 c 0,1.108 0.892,2 2,2 l 2,0 0,-6 4,0 0,6 2,0 c 1.108,0 2,-0.892 2,-2 l 0,-7 z"
-       style="fill:#3c2f1b;fill-opacity:1" />
-    <path
-       sodipodi:nodetypes="ccccccc"
-       inkscape:connector-curvature="0"
-       id="path3761"
-       d="m 2,6 c -2.20338983,2 -3,2 0,2 l 12,0 c 3,0 2.288136,0 0,-2 L 9,1 C 8,0 8,0 7,1 z"
-       style="fill:#3c2f1b;fill-opacity:1;stroke:none" />
-    <path
-       sodipodi:nodetypes="ssccss"
-       inkscape:connector-curvature="0"
-       id="rect3763"
-       d="m 13,1 c 1,0 1,0.446 1,1 l 0,4 -2,0 0,-4 c 0,-0.554 0,-1 1,-1 z"
-       style="fill:#3c2f1b;fill-opacity:1;stroke:none" />
-  </g>
+  <path
+     style="fill:#000000;fill-opacity:0.32156864"
+     d="M 48 40.5 C 47.5 40.5 47 41 46 42 L 36 52 C 31.593223 55.999998 30.000003 56 36 56 L 36 68 C 36 70.215999 37.784001 72 40 72 L 44 72 L 44 60 L 52 60 L 52 72 L 56 72 C 58.215999 72 60 70.215999 60 68 L 60 56 C 65.999997 56 64.57627 55.999998 60 52 L 60 44 C 60 42.892001 59.999999 42 58 42 C 56.000001 42 56 42.892001 56 44 L 56 48 L 50 42 C 49 41 48.5 40.5 48 40.5 z "
+     id="rect2989" />
 </svg>

--- a/styles/2/Numix/96x96/places/grey-user-home.svg
+++ b/styles/2/Numix/96x96/places/grey-user-home.svg
@@ -12,8 +12,8 @@
    height="96"
    id="svg2999"
    version="1.1"
-   inkscape:version="0.48.5 r10040"
-   sodipodi:docname="user-home.svg">
+   inkscape:version="0.91 r"
+   sodipodi:docname="grey-user-home.svg">
   <metadata
      id="metadata3017">
     <rdf:RDF>
@@ -36,15 +36,15 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1280"
-     inkscape:window-height="998"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
      id="namedview3013"
      showgrid="true"
      inkscape:zoom="9.8333333"
-     inkscape:cx="39.012102"
+     inkscape:cx="16.130746"
      inkscape:cy="31.622922"
      inkscape:window-x="0"
-     inkscape:window-y="0"
+     inkscape:window-y="21"
      inkscape:window-maximized="1"
      inkscape:current-layer="svg2999">
     <inkscape:grid
@@ -66,27 +66,8 @@
      style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#000000;fill-opacity:0.32156863;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
      d="m 12.000041,12.000037 c -1.999999,0 -3.999998,1.999998 -3.999998,3.999997 l 0,3.999998 -1.999999,0 c -1.999999,0 -4.0111358,1.898413 -3.999998,3.999998 l 0,55.999972 C 2.000302,82.241469 4.075571,83.9998 6.3750438,84 L 89.625002,84 C 92.000001,84 94,82.000001 94,80.000002 l 0,-49.999975 c 0,-1.999999 -1.999999,-3.999998 -3.999998,-3.999998 l -3.999998,0 0,-9.999995 c 0,-1.999999 -1.999999,-3.999997 -3.999998,-3.999997 l -69.999965,0 z m -5.999997,9.999994 47.999976,0 c 1.014627,0 1.999999,0.988334 1.999999,1.999999 l 0,3.999998 33.999983,0 c 1.081715,0 1.999999,0.943618 1.999999,1.999999 l 0,49.999975 c 0,1.107509 -0.90423,1.999999 -1.999999,1.999999 l -83.999958,0 c -1.0254515,0 -1.999999,-0.892492 -1.999999,-1.999999 l 0,-55.999972 c 0,-1.086635 0.9580835,-1.999999 1.999999,-1.999999 z"
      id="path3779" />
-  <g
-     id="g4056"
-     transform="matrix(1.999999,0,0,1.999999,31.999985,40.000022)"
-     style="opacity:0.4;fill:#3c2f1b;fill-opacity:1">
-    <path
-       sodipodi:nodetypes="cssccccsscc"
-       inkscape:connector-curvature="0"
-       id="rect2989"
-       d="m 2,7 0,7 c 0,1.108 0.892,2 2,2 l 2,0 0,-6 4,0 0,6 2,0 c 1.108,0 2,-0.892 2,-2 l 0,-7 z"
-       style="fill:#3c2f1b;fill-opacity:1" />
-    <path
-       sodipodi:nodetypes="ccccccc"
-       inkscape:connector-curvature="0"
-       id="path3761"
-       d="m 2,6 c -2.20338983,2 -3,2 0,2 l 12,0 c 3,0 2.288136,0 0,-2 L 9,1 C 8,0 8,0 7,1 z"
-       style="fill:#3c2f1b;fill-opacity:1;stroke:none" />
-    <path
-       sodipodi:nodetypes="ssccss"
-       inkscape:connector-curvature="0"
-       id="rect3763"
-       d="m 13,1 c 1,0 1,0.446 1,1 l 0,4 -2,0 0,-4 c 0,-0.554 0,-1 1,-1 z"
-       style="fill:#3c2f1b;fill-opacity:1;stroke:none" />
-  </g>
+  <path
+     style="fill:#000000;fill-opacity:0.32156864"
+     d="M 48 40.5 C 47.5 40.5 47 41 46 42 L 36 52 C 31.593223 55.999998 30.000003 56 36 56 L 36 68 C 36 70.215999 37.784001 72 40 72 L 44 72 L 44 60 L 52 60 L 52 72 L 56 72 C 58.215999 72 60 70.215999 60 68 L 60 56 C 65.999997 56 64.57627 55.999998 60 52 L 60 44 C 60 42.892001 59.999999 42 58 42 C 56.000001 42 56 42.892001 56 44 L 56 48 L 50 42 C 49 41 48.5 40.5 48 40.5 z "
+     id="rect2989" />
 </svg>

--- a/styles/2/Numix/96x96/places/orange-user-home.svg
+++ b/styles/2/Numix/96x96/places/orange-user-home.svg
@@ -12,8 +12,8 @@
    height="96"
    id="svg2999"
    version="1.1"
-   inkscape:version="0.48.5 r10040"
-   sodipodi:docname="user-home.svg">
+   inkscape:version="0.91 r"
+   sodipodi:docname="orange-user-home.svg">
   <metadata
      id="metadata3017">
     <rdf:RDF>
@@ -36,15 +36,15 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1280"
-     inkscape:window-height="998"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
      id="namedview3013"
      showgrid="true"
-     inkscape:zoom="9.8333333"
-     inkscape:cx="39.012102"
-     inkscape:cy="31.622922"
+     inkscape:zoom="4.9166667"
+     inkscape:cx="-3.3622664"
+     inkscape:cy="30.898518"
      inkscape:window-x="0"
-     inkscape:window-y="0"
+     inkscape:window-y="21"
      inkscape:window-maximized="1"
      inkscape:current-layer="svg2999">
     <inkscape:grid
@@ -66,27 +66,8 @@
      style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#000000;fill-opacity:0.32156863;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
      d="m 12.000041,12.000037 c -1.999999,0 -3.999998,1.999998 -3.999998,3.999997 l 0,3.999998 -1.999999,0 c -1.999999,0 -4.0111358,1.898413 -3.999998,3.999998 l 0,55.999972 C 2.000302,82.241469 4.075571,83.9998 6.3750438,84 L 89.625002,84 C 92.000001,84 94,82.000001 94,80.000002 l 0,-49.999975 c 0,-1.999999 -1.999999,-3.999998 -3.999998,-3.999998 l -3.999998,0 0,-9.999995 c 0,-1.999999 -1.999999,-3.999997 -3.999998,-3.999997 l -69.999965,0 z m -5.999997,9.999994 47.999976,0 c 1.014627,0 1.999999,0.988334 1.999999,1.999999 l 0,3.999998 33.999983,0 c 1.081715,0 1.999999,0.943618 1.999999,1.999999 l 0,49.999975 c 0,1.107509 -0.90423,1.999999 -1.999999,1.999999 l -83.999958,0 c -1.0254515,0 -1.999999,-0.892492 -1.999999,-1.999999 l 0,-55.999972 c 0,-1.086635 0.9580835,-1.999999 1.999999,-1.999999 z"
      id="path3779" />
-  <g
-     id="g4056"
-     transform="matrix(1.999999,0,0,1.999999,31.999985,40.000022)"
-     style="opacity:0.4;fill:#3c2f1b;fill-opacity:1">
-    <path
-       sodipodi:nodetypes="cssccccsscc"
-       inkscape:connector-curvature="0"
-       id="rect2989"
-       d="m 2,7 0,7 c 0,1.108 0.892,2 2,2 l 2,0 0,-6 4,0 0,6 2,0 c 1.108,0 2,-0.892 2,-2 l 0,-7 z"
-       style="fill:#3c2f1b;fill-opacity:1" />
-    <path
-       sodipodi:nodetypes="ccccccc"
-       inkscape:connector-curvature="0"
-       id="path3761"
-       d="m 2,6 c -2.20338983,2 -3,2 0,2 l 12,0 c 3,0 2.288136,0 0,-2 L 9,1 C 8,0 8,0 7,1 z"
-       style="fill:#3c2f1b;fill-opacity:1;stroke:none" />
-    <path
-       sodipodi:nodetypes="ssccss"
-       inkscape:connector-curvature="0"
-       id="rect3763"
-       d="m 13,1 c 1,0 1,0.446 1,1 l 0,4 -2,0 0,-4 c 0,-0.554 0,-1 1,-1 z"
-       style="fill:#3c2f1b;fill-opacity:1;stroke:none" />
-  </g>
+  <path
+     style="fill:#000000;fill-opacity:0.32156864"
+     d="M 48 40.5 C 47.5 40.5 47 41 46 42 L 36 52 C 31.593223 55.999998 30.000003 56 36 56 L 36 68 C 36 70.215999 37.784001 72 40 72 L 44 72 L 44 60 L 52 60 L 52 72 L 56 72 C 58.215999 72 60 70.215999 60 68 L 60 56 C 65.999997 56 64.57627 55.999998 60 52 L 60 44 C 60 42.892001 59.999999 42 58 42 C 56.000001 42 56 42.892001 56 44 L 56 48 L 50 42 C 49 41 48.5 40.5 48 40.5 z "
+     id="rect2989" />
 </svg>

--- a/styles/2/Numix/96x96/places/pink-user-home.svg
+++ b/styles/2/Numix/96x96/places/pink-user-home.svg
@@ -12,8 +12,8 @@
    height="96"
    id="svg2999"
    version="1.1"
-   inkscape:version="0.48.5 r10040"
-   sodipodi:docname="user-home.svg">
+   inkscape:version="0.91 r"
+   sodipodi:docname="pink-user-home.svg">
   <metadata
      id="metadata3017">
     <rdf:RDF>
@@ -36,15 +36,15 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1280"
-     inkscape:window-height="998"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
      id="namedview3013"
      showgrid="true"
-     inkscape:zoom="9.8333333"
-     inkscape:cx="39.012102"
-     inkscape:cy="31.622922"
+     inkscape:zoom="4.9166667"
+     inkscape:cx="10.577465"
+     inkscape:cy="31.851662"
      inkscape:window-x="0"
-     inkscape:window-y="0"
+     inkscape:window-y="21"
      inkscape:window-maximized="1"
      inkscape:current-layer="svg2999">
     <inkscape:grid
@@ -66,27 +66,8 @@
      style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#000000;fill-opacity:0.32156863;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
      d="m 12.000041,12.000037 c -1.999999,0 -3.999998,1.999998 -3.999998,3.999997 l 0,3.999998 -1.999999,0 c -1.999999,0 -4.0111358,1.898413 -3.999998,3.999998 l 0,55.999972 C 2.000302,82.241469 4.075571,83.9998 6.3750438,84 L 89.625002,84 C 92.000001,84 94,82.000001 94,80.000002 l 0,-49.999975 c 0,-1.999999 -1.999999,-3.999998 -3.999998,-3.999998 l -3.999998,0 0,-9.999995 c 0,-1.999999 -1.999999,-3.999997 -3.999998,-3.999997 l -69.999965,0 z m -5.999997,9.999994 47.999976,0 c 1.014627,0 1.999999,0.988334 1.999999,1.999999 l 0,3.999998 33.999983,0 c 1.081715,0 1.999999,0.943618 1.999999,1.999999 l 0,49.999975 c 0,1.107509 -0.90423,1.999999 -1.999999,1.999999 l -83.999958,0 c -1.0254515,0 -1.999999,-0.892492 -1.999999,-1.999999 l 0,-55.999972 c 0,-1.086635 0.9580835,-1.999999 1.999999,-1.999999 z"
      id="path3779" />
-  <g
-     id="g4056"
-     transform="matrix(1.999999,0,0,1.999999,31.999985,40.000022)"
-     style="opacity:0.4;fill:#3c2f1b;fill-opacity:1">
-    <path
-       sodipodi:nodetypes="cssccccsscc"
-       inkscape:connector-curvature="0"
-       id="rect2989"
-       d="m 2,7 0,7 c 0,1.108 0.892,2 2,2 l 2,0 0,-6 4,0 0,6 2,0 c 1.108,0 2,-0.892 2,-2 l 0,-7 z"
-       style="fill:#3c2f1b;fill-opacity:1" />
-    <path
-       sodipodi:nodetypes="ccccccc"
-       inkscape:connector-curvature="0"
-       id="path3761"
-       d="m 2,6 c -2.20338983,2 -3,2 0,2 l 12,0 c 3,0 2.288136,0 0,-2 L 9,1 C 8,0 8,0 7,1 z"
-       style="fill:#3c2f1b;fill-opacity:1;stroke:none" />
-    <path
-       sodipodi:nodetypes="ssccss"
-       inkscape:connector-curvature="0"
-       id="rect3763"
-       d="m 13,1 c 1,0 1,0.446 1,1 l 0,4 -2,0 0,-4 c 0,-0.554 0,-1 1,-1 z"
-       style="fill:#3c2f1b;fill-opacity:1;stroke:none" />
-  </g>
+  <path
+     style="fill:#000000;fill-opacity:0.32156864"
+     d="M 48 40.5 C 47.5 40.5 47 41 46 42 L 36 52 C 31.593223 55.999998 30.000003 56 36 56 L 36 68 C 36 70.215999 37.784001 72 40 72 L 44 72 L 44 60 L 52 60 L 52 72 L 56 72 C 58.215999 72 60 70.215999 60 68 L 60 56 C 65.999997 56 64.57627 55.999998 60 52 L 60 44 C 60 42.892001 59.999999 42 58 42 C 56.000001 42 56 42.892001 56 44 L 56 48 L 50 42 C 49 41 48.5 40.5 48 40.5 z "
+     id="rect2989" />
 </svg>

--- a/styles/2/Numix/96x96/places/purple-user-home.svg
+++ b/styles/2/Numix/96x96/places/purple-user-home.svg
@@ -12,8 +12,8 @@
    height="96"
    id="svg2999"
    version="1.1"
-   inkscape:version="0.48.5 r10040"
-   sodipodi:docname="user-home.svg">
+   inkscape:version="0.91 r"
+   sodipodi:docname="purple-user-home.svg">
   <metadata
      id="metadata3017">
     <rdf:RDF>
@@ -36,15 +36,15 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1280"
-     inkscape:window-height="998"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
      id="namedview3013"
      showgrid="true"
-     inkscape:zoom="9.8333333"
-     inkscape:cx="39.012102"
-     inkscape:cy="31.622922"
+     inkscape:zoom="4.9166667"
+     inkscape:cx="30.531132"
+     inkscape:cy="52.292854"
      inkscape:window-x="0"
-     inkscape:window-y="0"
+     inkscape:window-y="21"
      inkscape:window-maximized="1"
      inkscape:current-layer="svg2999">
     <inkscape:grid
@@ -66,27 +66,8 @@
      style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#000000;fill-opacity:0.32156863;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
      d="m 12.000041,12.000037 c -1.999999,0 -3.999998,1.999998 -3.999998,3.999997 l 0,3.999998 -1.999999,0 c -1.999999,0 -4.0111358,1.898413 -3.999998,3.999998 l 0,55.999972 C 2.000302,82.241469 4.075571,83.9998 6.3750438,84 L 89.625002,84 C 92.000001,84 94,82.000001 94,80.000002 l 0,-49.999975 c 0,-1.999999 -1.999999,-3.999998 -3.999998,-3.999998 l -3.999998,0 0,-9.999995 c 0,-1.999999 -1.999999,-3.999997 -3.999998,-3.999997 l -69.999965,0 z m -5.999997,9.999994 47.999976,0 c 1.014627,0 1.999999,0.988334 1.999999,1.999999 l 0,3.999998 33.999983,0 c 1.081715,0 1.999999,0.943618 1.999999,1.999999 l 0,49.999975 c 0,1.107509 -0.90423,1.999999 -1.999999,1.999999 l -83.999958,0 c -1.0254515,0 -1.999999,-0.892492 -1.999999,-1.999999 l 0,-55.999972 c 0,-1.086635 0.9580835,-1.999999 1.999999,-1.999999 z"
      id="path3779" />
-  <g
-     id="g4056"
-     transform="matrix(1.999999,0,0,1.999999,31.999985,40.000022)"
-     style="opacity:0.4;fill:#3c2f1b;fill-opacity:1">
-    <path
-       sodipodi:nodetypes="cssccccsscc"
-       inkscape:connector-curvature="0"
-       id="rect2989"
-       d="m 2,7 0,7 c 0,1.108 0.892,2 2,2 l 2,0 0,-6 4,0 0,6 2,0 c 1.108,0 2,-0.892 2,-2 l 0,-7 z"
-       style="fill:#3c2f1b;fill-opacity:1" />
-    <path
-       sodipodi:nodetypes="ccccccc"
-       inkscape:connector-curvature="0"
-       id="path3761"
-       d="m 2,6 c -2.20338983,2 -3,2 0,2 l 12,0 c 3,0 2.288136,0 0,-2 L 9,1 C 8,0 8,0 7,1 z"
-       style="fill:#3c2f1b;fill-opacity:1;stroke:none" />
-    <path
-       sodipodi:nodetypes="ssccss"
-       inkscape:connector-curvature="0"
-       id="rect3763"
-       d="m 13,1 c 1,0 1,0.446 1,1 l 0,4 -2,0 0,-4 c 0,-0.554 0,-1 1,-1 z"
-       style="fill:#3c2f1b;fill-opacity:1;stroke:none" />
-  </g>
+  <path
+     style="fill:#000000;fill-opacity:0.32156864"
+     d="M 48 40.5 C 47.5 40.5 47 41 46 42 L 36 52 C 31.593223 55.999998 30.000003 56 36 56 L 36 68 C 36 70.215999 37.784001 72 40 72 L 44 72 L 44 60 L 52 60 L 52 72 L 56 72 C 58.215999 72 60 70.215999 60 68 L 60 56 C 65.999997 56 64.57627 55.999998 60 52 L 60 44 C 60 42.892001 59.999999 42 58 42 C 56.000001 42 56 42.892001 56 44 L 56 48 L 50 42 C 49 41 48.5 40.5 48 40.5 z "
+     id="rect2989" />
 </svg>

--- a/styles/2/Numix/96x96/places/red-user-home.svg
+++ b/styles/2/Numix/96x96/places/red-user-home.svg
@@ -12,8 +12,8 @@
    height="96"
    id="svg2999"
    version="1.1"
-   inkscape:version="0.48.5 r10040"
-   sodipodi:docname="user-home.svg">
+   inkscape:version="0.91 r"
+   sodipodi:docname="red-user-home.svg">
   <metadata
      id="metadata3017">
     <rdf:RDF>
@@ -36,15 +36,15 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1280"
-     inkscape:window-height="998"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
      id="namedview3013"
      showgrid="true"
      inkscape:zoom="9.8333333"
-     inkscape:cx="39.012102"
+     inkscape:cx="16.130746"
      inkscape:cy="31.622922"
      inkscape:window-x="0"
-     inkscape:window-y="0"
+     inkscape:window-y="21"
      inkscape:window-maximized="1"
      inkscape:current-layer="svg2999">
     <inkscape:grid
@@ -66,27 +66,8 @@
      style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#000000;fill-opacity:0.32156863;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
      d="m 12.000041,12.000037 c -1.999999,0 -3.999998,1.999998 -3.999998,3.999997 l 0,3.999998 -1.999999,0 c -1.999999,0 -4.0111358,1.898413 -3.999998,3.999998 l 0,55.999972 C 2.000302,82.241469 4.075571,83.9998 6.3750438,84 L 89.625002,84 C 92.000001,84 94,82.000001 94,80.000002 l 0,-49.999975 c 0,-1.999999 -1.999999,-3.999998 -3.999998,-3.999998 l -3.999998,0 0,-9.999995 c 0,-1.999999 -1.999999,-3.999997 -3.999998,-3.999997 l -69.999965,0 z m -5.999997,9.999994 47.999976,0 c 1.014627,0 1.999999,0.988334 1.999999,1.999999 l 0,3.999998 33.999983,0 c 1.081715,0 1.999999,0.943618 1.999999,1.999999 l 0,49.999975 c 0,1.107509 -0.90423,1.999999 -1.999999,1.999999 l -83.999958,0 c -1.0254515,0 -1.999999,-0.892492 -1.999999,-1.999999 l 0,-55.999972 c 0,-1.086635 0.9580835,-1.999999 1.999999,-1.999999 z"
      id="path3779" />
-  <g
-     id="g4056"
-     transform="matrix(1.999999,0,0,1.999999,31.999985,40.000022)"
-     style="opacity:0.4;fill:#3c2f1b;fill-opacity:1">
-    <path
-       sodipodi:nodetypes="cssccccsscc"
-       inkscape:connector-curvature="0"
-       id="rect2989"
-       d="m 2,7 0,7 c 0,1.108 0.892,2 2,2 l 2,0 0,-6 4,0 0,6 2,0 c 1.108,0 2,-0.892 2,-2 l 0,-7 z"
-       style="fill:#3c2f1b;fill-opacity:1" />
-    <path
-       sodipodi:nodetypes="ccccccc"
-       inkscape:connector-curvature="0"
-       id="path3761"
-       d="m 2,6 c -2.20338983,2 -3,2 0,2 l 12,0 c 3,0 2.288136,0 0,-2 L 9,1 C 8,0 8,0 7,1 z"
-       style="fill:#3c2f1b;fill-opacity:1;stroke:none" />
-    <path
-       sodipodi:nodetypes="ssccss"
-       inkscape:connector-curvature="0"
-       id="rect3763"
-       d="m 13,1 c 1,0 1,0.446 1,1 l 0,4 -2,0 0,-4 c 0,-0.554 0,-1 1,-1 z"
-       style="fill:#3c2f1b;fill-opacity:1;stroke:none" />
-  </g>
+  <path
+     style="fill:#000000;fill-opacity:0.32156864"
+     d="M 48 40.5 C 47.5 40.5 47 41 46 42 L 36 52 C 31.593223 55.999998 30.000003 56 36 56 L 36 68 C 36 70.215999 37.784001 72 40 72 L 44 72 L 44 60 L 52 60 L 52 72 L 56 72 C 58.215999 72 60 70.215999 60 68 L 60 56 C 65.999997 56 64.57627 55.999998 60 52 L 60 44 C 60 42.892001 59.999999 42 58 42 C 56.000001 42 56 42.892001 56 44 L 56 48 L 50 42 C 49 41 48.5 40.5 48 40.5 z "
+     id="rect2989" />
 </svg>

--- a/styles/2/Numix/96x96/places/yellow-user-home.svg
+++ b/styles/2/Numix/96x96/places/yellow-user-home.svg
@@ -12,8 +12,8 @@
    height="96"
    id="svg2999"
    version="1.1"
-   inkscape:version="0.48.5 r10040"
-   sodipodi:docname="user-home.svg">
+   inkscape:version="0.91 r"
+   sodipodi:docname="yellow-user-home.svg">
   <metadata
      id="metadata3017">
     <rdf:RDF>
@@ -36,15 +36,15 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1280"
-     inkscape:window-height="998"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
      id="namedview3013"
      showgrid="true"
      inkscape:zoom="9.8333333"
-     inkscape:cx="39.012102"
+     inkscape:cx="16.130746"
      inkscape:cy="31.622922"
      inkscape:window-x="0"
-     inkscape:window-y="0"
+     inkscape:window-y="21"
      inkscape:window-maximized="1"
      inkscape:current-layer="svg2999">
     <inkscape:grid
@@ -66,27 +66,8 @@
      style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#000000;fill-opacity:0.32156863;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
      d="m 12.000041,12.000037 c -1.999999,0 -3.999998,1.999998 -3.999998,3.999997 l 0,3.999998 -1.999999,0 c -1.999999,0 -4.0111358,1.898413 -3.999998,3.999998 l 0,55.999972 C 2.000302,82.241469 4.075571,83.9998 6.3750438,84 L 89.625002,84 C 92.000001,84 94,82.000001 94,80.000002 l 0,-49.999975 c 0,-1.999999 -1.999999,-3.999998 -3.999998,-3.999998 l -3.999998,0 0,-9.999995 c 0,-1.999999 -1.999999,-3.999997 -3.999998,-3.999997 l -69.999965,0 z m -5.999997,9.999994 47.999976,0 c 1.014627,0 1.999999,0.988334 1.999999,1.999999 l 0,3.999998 33.999983,0 c 1.081715,0 1.999999,0.943618 1.999999,1.999999 l 0,49.999975 c 0,1.107509 -0.90423,1.999999 -1.999999,1.999999 l -83.999958,0 c -1.0254515,0 -1.999999,-0.892492 -1.999999,-1.999999 l 0,-55.999972 c 0,-1.086635 0.9580835,-1.999999 1.999999,-1.999999 z"
      id="path3779" />
-  <g
-     id="g4056"
-     transform="matrix(1.999999,0,0,1.999999,31.999985,40.000022)"
-     style="opacity:0.4;fill:#3c2f1b;fill-opacity:1">
-    <path
-       sodipodi:nodetypes="cssccccsscc"
-       inkscape:connector-curvature="0"
-       id="rect2989"
-       d="m 2,7 0,7 c 0,1.108 0.892,2 2,2 l 2,0 0,-6 4,0 0,6 2,0 c 1.108,0 2,-0.892 2,-2 l 0,-7 z"
-       style="fill:#3c2f1b;fill-opacity:1" />
-    <path
-       sodipodi:nodetypes="ccccccc"
-       inkscape:connector-curvature="0"
-       id="path3761"
-       d="m 2,6 c -2.20338983,2 -3,2 0,2 l 12,0 c 3,0 2.288136,0 0,-2 L 9,1 C 8,0 8,0 7,1 z"
-       style="fill:#3c2f1b;fill-opacity:1;stroke:none" />
-    <path
-       sodipodi:nodetypes="ssccss"
-       inkscape:connector-curvature="0"
-       id="rect3763"
-       d="m 13,1 c 1,0 1,0.446 1,1 l 0,4 -2,0 0,-4 c 0,-0.554 0,-1 1,-1 z"
-       style="fill:#3c2f1b;fill-opacity:1;stroke:none" />
-  </g>
+  <path
+     style="fill:#000000;fill-opacity:0.32156864"
+     d="M 48 40.5 C 47.5 40.5 47 41 46 42 L 36 52 C 31.593223 55.999998 30.000003 56 36 56 L 36 68 C 36 70.215999 37.784001 72 40 72 L 44 72 L 44 60 L 52 60 L 52 72 L 56 72 C 58.215999 72 60 70.215999 60 68 L 60 56 C 65.999997 56 64.57627 55.999998 60 52 L 60 44 C 60 42.892001 59.999999 42 58 42 C 56.000001 42 56 42.892001 56 44 L 56 48 L 50 42 C 49 41 48.5 40.5 48 40.5 z "
+     id="rect2989" />
 </svg>


### PR DESCRIPTION
In style 2 *user-home.svg in size 48 and 96 the symbol was wrongly coloured and inconsistent with other symbols (see screenshot)
![bildschirmfoto vom 2015-05-04 19 41 04](https://cloud.githubusercontent.com/assets/6475757/7458973/f63e036a-f298-11e4-82a9-b2fa55df7acb.png)
![bildschirmfoto vom 2015-05-04 19 41 28](https://cloud.githubusercontent.com/assets/6475757/7458996/1e2bcc22-f299-11e4-8f29-0a5c7f4eaaf4.png)
