### PR TITLE
Fixes #91

### DIFF
--- a/numix-folders
+++ b/numix-folders
@@ -204,6 +204,9 @@ currentcolour=$(readlink ${dir}/Numix/16x16/places/folder.svg | cut -d '-' -f 1)
 links=$(find -L ${dir}/Numix/*/{actions,places} -xtype l)
 
 for link in $links; do
+    if [[ $link == *folder_color* ]]; then 
+        continue
+    fi
     newlink=$(readlink "${link}");
     if [[ $newlink == *"$currentcolour"* ]]; then
         newlink=${newlink/${currentcolour}/${colour}}


### PR DESCRIPTION
Fixes #91. The problem was, that all symlinks for folder_color support were overwritten as soon as a global color was used. I changed that so that all the `folder_color` symlinks remain unchanged when changing the global colour