### PR TITLE
Use absolute paths instead of relative paths

### DIFF
--- a/gui/gui
+++ b/gui/gui
@@ -3,6 +3,7 @@
 from gi.repository import Gtk, Gdk, GdkPixbuf, Pango
 from re import search
 from sys import argv
+from os import path
 
 
 def get_default_colour(colour):
@@ -115,7 +116,7 @@ class NumixFoldersGUI(Gtk.Window):
         self.svgs = []
         for i in range(number_styles):
             hboxpics.append(Gtk.HBox())
-            with open("./styles/"+str(i+1)+"/Numix/48x48/places/custom-user-home.svg", "r") as svgfile:
+            with open(path.split(path.abspath(__file__))[0]+"/../styles/"+str(i+1)+"/Numix/48x48/places/custom-user-home.svg", "r") as svgfile:
                 self.svgs.append(svgfile.read())
             self.image.append(Gtk.Image())
             self.image[i].show()

--- a/numix-folders
+++ b/numix-folders
@@ -80,6 +80,8 @@ if [ ! -f "$config_file" ];then
   touch "$config_file"
 fi
 
+scriptpath=$(dirname "$(readlink -f "$0")")
+
 if [ "$runmode" -eq 2 ]; then
     if [ -d /home/"$cuser"/.local/share/icons/Numix/ ]; then
         dir=/home/"$cuser"/.local/share/icons
@@ -93,7 +95,7 @@ if [ "$runmode" -eq 2 ]; then
             dir=/usr/share/icons
         fi
     else
-        ./gui/error
+        "$scriptpath"/gui/error
         exit
     fi
     style=$(sed -n 1p "$config_file")
@@ -101,7 +103,7 @@ if [ "$runmode" -eq 2 ]; then
     colour1=$(sed -n 3p "$config_file")
     colour2=$(sed -n 4p "$config_file")
     colour3=$(sed -n 5p "$config_file")
-    vars=$(./gui/gui "$style" "$colour" "#$colour1" "#$colour2" "#$colour3")
+    vars=$("$scriptpath"/gui/gui "$style" "$colour" "#$colour1" "#$colour2" "#$colour3")
     style=$(echo $vars | awk '{print $1}')
     colour=$(echo $vars | awk '{print $2}')
     colour1=$(echo $vars | awk '{print $3}')
@@ -111,9 +113,9 @@ if [ "$runmode" -eq 2 ]; then
         exit
     fi
     if [[ $UID -ne 0 ]]; then
-        ./gui/notification&
+        "$scriptpath"/gui/notification&
     else
-        sudo -H -u "$cuser" ./gui/notification&
+        sudo -H -u "$cuser" "$scriptpath"/gui/notification&
     fi
 
 else
@@ -140,34 +142,11 @@ else
     exitloop=0
     until [ "$exitloop" -eq 1 ]; do
         case $runmode in
-            1)
-                echo "Trying to use previously stored settings"
-                style=$(sed -n 1p "$config_file")
-                colour=$(sed -n 2p "$config_file")
-                colour1=$(sed -n 3p "$config_file")
-                colour2=$(sed -n 4p "$config_file")
-                colour3=$(sed -n 5p "$config_file")
-                if [[ "$style" -gt 6 || "$style" -lt 1 ]] || [[ -z $colour ]]; then
-                    exitloop=0
-                    runmode=0
-                    echo "There were errors in your config file!"
-                    continue
-                fi
-                if [ "$colour" == "custom" ]; then
-                    if ! [[ "$colour1" =~ ^[0-9A-Fa-f]{6}$ ]] || ! [[ "$colour2" =~ ^[0-9A-Fa-f]{6}$ ]] || ! [[ "$colour3" =~ ^[0-9A-Fa-f]{6}$ ]]; then
-                        exitloop=0
-                        runmode=0
-                        echo "There were errors in your config file!"
-                        continue
-                    fi
-                fi
-                exitloop=1
-                ;;
             0)
                 read -r -p "Which folder style do you want? " answer
                 if [ -z "$answer" ]; then
                     style="0"
-                elif [ -d styles/"$answer" ]; then
+                elif [ -d "$scriptpath"/styles/"$answer" ]; then
                     style="$answer"
                 else
                     echo -e \
@@ -269,11 +248,34 @@ else
                 fi
                 exitloop=1
                 ;;
+            1)
+                echo "Trying to use previously stored settings"
+                style=$(sed -n 1p "$config_file")
+                colour=$(sed -n 2p "$config_file")
+                colour1=$(sed -n 3p "$config_file")
+                colour2=$(sed -n 4p "$config_file")
+                colour3=$(sed -n 5p "$config_file")
+                if [[ "$style" -gt 6 || "$style" -lt 1 ]] || [[ -z $colour ]]; then
+                    exitloop=0
+                    runmode=0
+                    echo "There were errors in your config file!"
+                    continue
+                fi
+                if [ "$colour" == "custom" ]; then
+                    if ! [[ "$colour1" =~ ^[0-9A-Fa-f]{6}$ ]] || ! [[ "$colour2" =~ ^[0-9A-Fa-f]{6}$ ]] || ! [[ "$colour3" =~ ^[0-9A-Fa-f]{6}$ ]]; then
+                        exitloop=0
+                        runmode=0
+                        echo "There were errors in your config file!"
+                        continue
+                    fi
+                fi
+                exitloop=1
+                ;;
         esac
     done
 fi
 
-cp -rf styles/"${style}"/Numix/* "${dir}"/Numix/
+cp -rf "$scriptpath"/styles/"${style}"/Numix/* "${dir}"/Numix/
 
 if [ "$colour" == "custom" ]; then
     find ${dir}/Numix/*/{actions,places}/*custom* \
@@ -299,12 +301,12 @@ done
 chown -R "$cuser" "${dir}"/Numix/
 gtk-update-icon-cache -f "${dir}"/Numix/
 if [ -d "${dir}"/Numix-Circle/ ]; then
-    cp -rH styles/"${style}"/Numix-Circle/* "${dir}"/Numix-Circle/
+    cp -rH "$scriptpath"/styles/"${style}"/Numix-Circle/* "${dir}"/Numix-Circle/
     chown -R "$cuser" "${dir}"/Numix-Circle/
     gtk-update-icon-cache -f "${dir}"/Numix-Circle/
 fi
 if [ -d "${dir}"/Numix-Square/ ]; then
-    cp -rH styles/"${style}"/Numix-Square/* "${dir}"/Numix-Square/
+    cp -rH "$scriptpath"/styles/"${style}"/Numix-Square/* "${dir}"/Numix-Square/
     chown -R "$cuser" "${dir}"/Numix-Square/
     gtk-update-icon-cache -f "${dir}"/Numix-Square/
 fi


### PR DESCRIPTION
This will be important if we are going to use a desktop file, that calls the script via an absolute path: absolute paths to the script instead of relative paths... (I guess ths is the cleaner way, instead of `cd` into the folder at the beginning of the script)