### PR TITLE
Keep settings after upgrade of numix-folders

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -1,3 +1,4 @@
 cd /usr/bin/
 sudo touch numix-folders
 echo '#!/bin/bash \ncd /opt/numix-folders && ./numix-folders "$1"' > numix-folders && chmod a+x numix-folders
+$(command -v numix-folders) -p >/dev/null 2>&1


### PR DESCRIPTION
The launchpad ppa uses this branch for packaging. Changing this postinst script should be resetting the folders, the the previously selected values