### PR TITLE
get real home directory

### DIFF
--- a/numix-folders
+++ b/numix-folders
@@ -75,7 +75,7 @@ fi
 
 cuser="${SUDO_USER:-$USER}"
 
-config_file=/home/"$cuser"/.config/numix-folders
+config_file="$(eval echo "~$cuser")/.config/numix-folders"
 if [ ! -f "$config_file" ];then
   touch "$config_file"
 fi


### PR DESCRIPTION
We are running workstations with powerbroker active directory integration, where the home directory is somehing like ```/home/local/$DOMAIN_REALM/$USERNAME```, so the scripted version throws errors due to nonexistent default home dirs.