### PR TITLE
Replace gksudo with sudo

### DIFF
--- a/numix-folders
+++ b/numix-folders
@@ -90,7 +90,7 @@ if [ "$runmode" -eq 2 ]; then
     elif [ -d /usr/share/icons/Numix/ ]; then
         if [[ $UID -ne 0 ]]; then
             scriptname=$(readlink -f "$0")
-            exec gksudo "$scriptname"
+            exec sudo "$scriptname"
         else
             dir=/usr/share/icons
         fi


### PR DESCRIPTION
Hey, I used this repository directly in my 18.04 test pc and replacing `gksudo` with `sudo` allows it to use since gksu is not available anymore.