### PR TITLE
Fixed "gksudo no longer installed by default"

### DIFF
--- a/numix-folders
+++ b/numix-folders
@@ -90,7 +90,7 @@ if [ "$runmode" -eq 2 ]; then
     elif [ -d /usr/share/icons/Numix/ ]; then
         if [[ $UID -ne 0 ]]; then
             scriptname=$(readlink -f "$0")
-            exec gksudo "$scriptname"
+            pkexec "$scriptname"
         else
             dir=/usr/share/icons
         fi
@@ -321,3 +321,4 @@ echo "Folder change complete!"
 } > "$config_file"
 chown -R "$cuser" "$config_file"
 sucess
+


### PR DESCRIPTION
As "gksudo" is no longer installed by default in Ubuntu, I have replaced it by "pkexec" which is supported by default.

Ed: Fixes #162, fixes #178, and fixes #185  